### PR TITLE
Added MnbCurrentExchangeRatesController with unit tests.

### DIFF
--- a/CurrencyExchange.Application.Integration.Tests/mnb/MnbExchangeRateServiceTests.cs
+++ b/CurrencyExchange.Application.Integration.Tests/mnb/MnbExchangeRateServiceTests.cs
@@ -5,7 +5,7 @@ namespace CurrencyExchange.Application.Integration.Tests.mnb;
 
 public class MnbExchangeRateServiceTests
 {
-    private IMnbExchangeRateService _mnbExchangeRateService;
+    private readonly IMnbExchangeRateService _mnbExchangeRateService;
 
     public MnbExchangeRateServiceTests()
     {

--- a/CurrencyExchange.Application/mnb/Models/Day.cs
+++ b/CurrencyExchange.Application/mnb/Models/Day.cs
@@ -1,0 +1,14 @@
+using System.Xml.Serialization;
+
+namespace www.mnb.hu.webservices.Models;
+
+public class Day
+{
+    [XmlAttribute("date")]
+    public string ExchangeDateStr { get; set; }
+
+    public DateOnly ExchangeDate => DateOnly.Parse(ExchangeDateStr);
+
+    [XmlElement("Rate")]
+    public List<Rate> Rates { get; set; }
+}

--- a/CurrencyExchange.Application/mnb/Models/MnbCurrentExchangeRates.cs
+++ b/CurrencyExchange.Application/mnb/Models/MnbCurrentExchangeRates.cs
@@ -1,0 +1,9 @@
+using System.Xml.Serialization;
+
+namespace www.mnb.hu.webservices.Models;
+
+[XmlRoot]
+public class MNBCurrentExchangeRates
+{
+    [XmlElement(ElementName = "Day")] public Day Day { get; set; }
+}

--- a/CurrencyExchange.Application/mnb/Models/Rate.cs
+++ b/CurrencyExchange.Application/mnb/Models/Rate.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+using System.Xml.Serialization;
+
+namespace www.mnb.hu.webservices.Models;
+
+[XmlRoot("Rate")]
+public class Rate
+{
+    [XmlAttribute("curr")]
+    public string Currency { get; set; }
+
+    [XmlAttribute("unit")]
+    public string ExchangeUnit { get; set; }
+
+    [XmlText]
+    public string ValueStr { get; set; }
+
+    public decimal Value => decimal.Parse(ValueStr, new CultureInfo("hu-HU"));
+}

--- a/CurrencyExchange.Tests/Controllers/MnbCurrentExchangeRatesControllerTests.cs
+++ b/CurrencyExchange.Tests/Controllers/MnbCurrentExchangeRatesControllerTests.cs
@@ -1,0 +1,103 @@
+using CurrencyExchange.Controllers;
+using FluentAssertions;
+using NSubstitute;
+using www.mnb.hu.webservices;
+using www.mnb.hu.webservices.Models;
+
+namespace CurrencyExchange.Tests.Controllers;
+
+public class MnbCurrentExchangeRatesControllerTests
+{
+    private readonly IMnbExchangeRateService _mnbExchangeRateService;
+    private readonly MnbCurrentExchangeRatesController _mnbCurrentExchangeRatesController;
+
+    public MnbCurrentExchangeRatesControllerTests()
+    {
+        _mnbExchangeRateService = Substitute.For<IMnbExchangeRateService>();
+        _mnbExchangeRateService
+            .GetCurrentExchangeRatesAsync(Arg.Any<GetCurrentExchangeRatesRequestBody>())
+            .Returns(new GetCurrentExchangeRatesResponse
+            {
+                GetCurrentExchangeRatesResponse1 = new GetCurrentExchangeRatesResponseBody
+                {
+                    GetCurrentExchangeRatesResult = "<MNBCurrentExchangeRates></MNBCurrentExchangeRates>"
+                }
+            });
+        _mnbCurrentExchangeRatesController =
+            new MnbCurrentExchangeRatesController(_mnbExchangeRateService);
+    }
+
+    [Fact]
+    public async Task WhenRequestCurrentExchangeRates_ResultShouldNotBeNull()
+    {
+        var result = await _mnbCurrentExchangeRatesController.Get();
+
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task WhenRequestCurrentExchangeRates_ShouldCallServiceForData()
+    {
+        var result = await _mnbCurrentExchangeRatesController.Get();
+
+        await _mnbExchangeRateService.Received(1)
+            .GetCurrentExchangeRatesAsync(Arg.Any<GetCurrentExchangeRatesRequestBody>());
+    }
+
+    [Fact]
+    public async Task GivenValidCurrentExchangeRateData_WhenRequestCurrentExchangeRates_ShouldReturnExpectedType()
+    {
+        SetupMnbExchangeRateServiceWithRealData();
+
+        var result = await _mnbCurrentExchangeRatesController.Get();
+
+        result.Value.Should().BeOfType<MNBCurrentExchangeRates>();
+    }
+
+    [Fact]
+    public async Task GivenValidCurrentExchangeRateData_WhenRequestCurrentExchangeRates_ShouldReturnExpectedExchangeDate()
+    {
+        SetupMnbExchangeRateServiceWithRealData();
+
+        var result = await _mnbCurrentExchangeRatesController.Get();
+
+        ((MNBCurrentExchangeRates)result.Value!).Day.ExchangeDate.Should().Be(DateOnly.FromDateTime(new DateTime(2023, 10, 17)));
+    }
+
+    [Theory]
+    [InlineData("CHF", "72,65000", 72.65000)]
+    [InlineData("EUR", "232,23000", 232.23000)]
+    [InlineData("USD", "197,19000", 197.19000)]
+    public async Task GivenValidCurrentExchangeRateData_WhenRequestCurrentExchangeRates_ShouldReturnExpectedCurrencyValues(
+        string currencyName, string currencyValueStr, decimal currencyValue)
+    {
+        SetupMnbExchangeRateServiceWithRealData();
+
+        var result = await _mnbCurrentExchangeRatesController.Get();
+
+        ((MNBCurrentExchangeRates)result.Value!).Day.Rates.Should()
+            .ContainSingle(r =>
+                r.Currency == currencyName
+                && r.ValueStr == currencyValueStr
+                && r.Value == currencyValue);
+    }
+
+    private void SetupMnbExchangeRateServiceWithRealData()
+    {
+        _mnbExchangeRateService
+            .GetCurrentExchangeRatesAsync(Arg.Any<GetCurrentExchangeRatesRequestBody>())
+            .Returns(new GetCurrentExchangeRatesResponse
+            {
+                GetCurrentExchangeRatesResponse1 = new GetCurrentExchangeRatesResponseBody
+                {
+                    GetCurrentExchangeRatesResult = "<MNBCurrentExchangeRates>" +
+                                                    "    <Day date=\"2023-10-17\">\n" +
+                                                    "        <Rate curr=\"CHF\" unit=\"1\">72,65000</Rate>\n" +
+                                                    "        <Rate curr=\"EUR\" unit=\"1\">232,23000</Rate>\n" +
+                                                    "        <Rate curr=\"USD\" unit=\"1\">197,19000</Rate>\n" +
+                                                    "    </Day>\n" +
+                                                    "</MNBCurrentExchangeRates>"
+                }
+            });
+    }
+}

--- a/CurrencyExchange.Tests/CurrencyExchange.Tests.csproj
+++ b/CurrencyExchange.Tests/CurrencyExchange.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\CurrencyExchange.Application\CurrencyExchange.Application.csproj" />
+      <ProjectReference Include="..\CurrencyExchange\CurrencyExchange.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/CurrencyExchange.Tests/GlobalUsings.cs
+++ b/CurrencyExchange.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/CurrencyExchange.sln.sln
+++ b/CurrencyExchange.sln.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurrencyExchange.Applicatio
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurrencyExchange.Application.Integration.Tests", "CurrencyExchange.Application.Integration.Tests\CurrencyExchange.Application.Integration.Tests.csproj", "{58E97709-05C0-4AE3-B56A-8AC37080BDEC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurrencyExchange.Tests", "CurrencyExchange.Tests\CurrencyExchange.Tests.csproj", "{41B499CF-9933-4D09-A5EF-DF8EA45A3A1C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,5 +44,9 @@ Global
 		{58E97709-05C0-4AE3-B56A-8AC37080BDEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{58E97709-05C0-4AE3-B56A-8AC37080BDEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{58E97709-05C0-4AE3-B56A-8AC37080BDEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41B499CF-9933-4D09-A5EF-DF8EA45A3A1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41B499CF-9933-4D09-A5EF-DF8EA45A3A1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41B499CF-9933-4D09-A5EF-DF8EA45A3A1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41B499CF-9933-4D09-A5EF-DF8EA45A3A1C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/CurrencyExchange/Controllers/MnbCurrentExchangeRatesController.cs
+++ b/CurrencyExchange/Controllers/MnbCurrentExchangeRatesController.cs
@@ -1,0 +1,38 @@
+using System.Xml.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using www.mnb.hu.webservices;
+using www.mnb.hu.webservices.Models;
+
+namespace CurrencyExchange.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class MnbCurrentExchangeRatesController : ControllerBase
+{
+    private readonly IMnbExchangeRateService _mnbExchangeRateService;
+
+    public MnbCurrentExchangeRatesController(IMnbExchangeRateService mnbExchangeRateService)
+    {
+        _mnbExchangeRateService = mnbExchangeRateService;
+    }
+
+    [HttpGet]
+    public async Task<JsonResult> Get()
+    {
+        var getCurrentExchangeRates =
+            await _mnbExchangeRateService.GetCurrentExchangeRatesAsync(new GetCurrentExchangeRatesRequestBody());
+        var currentExchangeRatesResponse =
+            getCurrentExchangeRates.GetCurrentExchangeRatesResponse1.GetCurrentExchangeRatesResult;
+
+
+        var serializer = new XmlSerializer(typeof(MNBCurrentExchangeRates));
+        MNBCurrentExchangeRates result;
+
+        using (TextReader reader = new StringReader(currentExchangeRatesResponse))
+        {
+            result = (MNBCurrentExchangeRates)serializer.Deserialize(reader);
+        }
+
+        return new JsonResult(result);
+    }
+}

--- a/CurrencyExchange/CurrencyExchange.csproj
+++ b/CurrencyExchange/CurrencyExchange.csproj
@@ -25,6 +25,12 @@
     <ProjectReference Include="..\CurrencyExchange.Application\CurrencyExchange.Application.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="CurrencyExchange.Application">
+      <HintPath>bin\Debug\net7.0\CurrencyExchange.Application.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
     <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">
     <!-- Ensure Node.js is installed -->
     <Exec Command="node --version" ContinueOnError="true">


### PR DESCRIPTION
## Purpose

This PR is about adding a new controller that'll return the current exchange rates based on the values provided by `MnbExchangeRateService`.

## Changes

The new controller`MnbCurrentExchangeRatesController` was added.
Unit tests are added to the controller `Get` method to validate that the controller returns the expected JSON response.

## Testing

The controller behavior can be tested through a REST API call by some REST client applications like below.

<details>
<summary>Screenshot</summary>

![image](https://github.com/bcsaba/CurrencyExchange/assets/3913211/6dbad01b-2d63-497b-8fe4-898b599b5caa)


</details>